### PR TITLE
Vagrantfile Modified

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,7 +25,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # Share the home directory for access to host source code
   # and use NFS for 10-100x speedup:
   # NOTE: you must have a network configured above, such as config.vm.network
-  # config.vm.synced_folder "~/", "/host", nfs: true
+  config.vm.synced_folder ".", "/vagrant"
 
   # Create a private network, which allows host-only access to the machine
   # using a specific IP.


### PR DESCRIPTION
By default, vagrant shares the project directory to the /vagrant directory in the guest machine. However in some cases, the project directory is not synced with the guest machine. As a result, when the user ssh into the guest machine, he may not find any /vagrant folder.

Adding above line to the Vagrantfile ensures that the project directory on the host machine is synced with the guest machine, and the project files would be present in the /vagrant folder. Any changes made to files in /vagrant folder in the guest machine, would then be reflected in the project directory on the host machine.
