### PR TITLE
SVG to PNG conversion functionality added.

### DIFF
--- a/assets/js/mmlc.js
+++ b/assets/js/mmlc.js
@@ -51,6 +51,11 @@ $('body').ready( function() {
 		$("#output-svg-markup").html(sanitizeMathML(data.svg));
 		$("#output-text").html(data.altText);
 		$("#output-url").html(data.cloudUrl);
+		var oCanvas=document.getElementById('output-svgImage');
+		var ctx = oCanvas.getContext('2d');
+		ctx.drawSvg(data.svg, 50 , 50 , 50, 50);
+		var DataURI=oCanvas.toDataURL('image/png');
+		document.getElementById("output-pngImage").src=DataURI;
 	}
 	
 	

--- a/views/home/index.ejs
+++ b/views/home/index.ejs
@@ -5,6 +5,11 @@
 	<br/>
 	<input type="submit" id="go" value="go"/>
 </form>
+
+<h2 id="svgImage"> Svg Image </h2>
+<canvas id="output-svgImage" width="100" height="100"></canvas>
+<h2 id="pngImage"> Png Image </h2>
+<img id="output-pngImage" name="empty" />
 <h2>MathML in the Cloud URL</h2>
 <div class="output" id="output-url"></div>
 <h2>Text Description</h2>

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -17,6 +17,9 @@
 		<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js"></script>
 		<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
 		<script type="text/javascript" src="/js/mmlc.js"></script>
+		<script type="text/javascript" src="http://canvg.googlecode.com/svn/trunk/rgbcolor.js"></script> 
+		<script type="text/javascript" src="http://canvg.googlecode.com/svn/trunk/StackBlur.js"></script>
+		<script type="text/javascript" src="http://canvg.googlecode.com/svn/trunk/canvg.js"></script>
   </head>
   <body>
     <!-- Include the view file for the current controller/route -->


### PR DESCRIPTION
I use the canvg library to render the SVG image on the Canvas element. I then use 'toDataURL() ' function of the canvas object to encode the image data as a base64 encoded PNG file and returns it as a data:URI. I then set this dataURI as the 'src' attribute of an image element.
