### PR TITLE
Set dependencies for mmlc-api service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,3 +17,6 @@ services:
     links:
       - mmlc-redis
       - mmlc-mongo
+    depends_on:
+      - mmlc-redis
+      - mmlc-mongo


### PR DESCRIPTION
Hello, I noticed the comment by @reedstrm on line 11 of the ```docker-compose.yml``` file:

```
  # Hopefully moving api to the bottom will ensure that mongo and redis start up :yn:
```
 
I hope the PR helps fix the file, it sounded like the issue is we want to ensure that Mongo and Redis startup before the API does - so I added the following lines to the bottom, using the ```depends-on``` directive:

```
    depends_on:
      - mmlc-redis
      - mmlc-mongo
```

On a separate note, I think the other issue might be the Node version being used on the Dockerfiles.

For example, the ```Dockerfile``` currently uses version 10, but the ```batik``` dependency seems to require version 10, 12, or 14 (based on the following output I got in Terminal):

```
npm install batik
npm WARN EBADENGINE Unsupported engine {
npm WARN EBADENGINE   package: 'jasmine@3.6.3',
npm WARN EBADENGINE   required: { node: '^10 || ^12 || ^14' },
npm WARN EBADENGINE   current: { node: 'v15.3.0', npm: '7.0.14' }
npm WARN EBADENGINE }
```

Let me know if that helps! 